### PR TITLE
Add winner detection

### DIFF
--- a/Agetns.md
+++ b/Agetns.md
@@ -15,6 +15,7 @@ Forrás URL sablon: `https://www.tennisabstract.com/cgi-bin/player.cgi?p=[tennis
 - `DF%`
 - `BPSvd`
 - **Opponent** (külön kérésre: az ellenfél neve). Az ellenfél neve a táblázatban a `vRk` és a `Score` oszlop **között** található cellában, és **mindig kattintható** (anchor `<a>`), ezért link segítségével azonosítjuk.
+- `Winner` (a győztes neve; ha az ellenfél neve a "d." előtt szerepel, akkor ő nyert, különben a forrás játékos).
 
 ## Bemenet és kimenet
 

--- a/Readme.md
+++ b/Readme.md
@@ -20,4 +20,5 @@ The generated CSV includes the following columns:
 - `DF%`
 - `BPSvd`
 - `Opponent`
+- `Winner`
 


### PR DESCRIPTION
## Summary
- determine match winner by parsing opponent column and comparing position around `d.`
- record winner in CSV output and documentation

## Testing
- `node scrape-tennisabstract.js players.txt output.csv` *(fails: net::ERR_TUNNEL_CONNECTION_FAILED)*

------
https://chatgpt.com/codex/tasks/task_e_68a47c956d148323a48d0444f7282ad4