### PR TITLE
Include Rd column in TennisAbstract scraper

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -13,6 +13,7 @@ The generated CSV includes the following columns:
 - `Plays`
 - `Date`
 - `Tournament`
+- `Rd`
 - `Rk`
 - `vRk`
 - `DR`

--- a/scrape-tennisabstract.js
+++ b/scrape-tennisabstract.js
@@ -86,13 +86,14 @@ async function scrapePlayer(page, playerName) {
     const idx = (name) => headers.indexOf(name);
 
     const dateIdx = idx("Date");
+    const tournamentIdx = idx("Tournament");
+    const rdIdx = idx("Rd");
     const rkIdx = idx("Rk");
+    const vRkIdx = idx("vRk");
     const drIdx = idx("DR");
     const aPctIdx = idx("A%");
     const dfPctIdx = idx("DF%");
     const bpsvdIdx = idx("BPSvd");
-    const tournamentIdx = idx("Tournament");
-    const vRkIdx = idx("vRk");
     const scoreIdx = idx("Score");
 
     // Ellenfél oszlop: a vRk és a Score között, és benne egy <a> link a játékos nevével
@@ -124,6 +125,7 @@ async function scrapePlayer(page, playerName) {
         return {
           Date: get(dateIdx),
           Tournament: get(tournamentIdx),
+          Rd: get(rdIdx),
           Rk: get(rkIdx),
           vRk: get(vRkIdx),
           DR: get(drIdx),
@@ -195,6 +197,7 @@ async function main() {
     "Plays",
     "Date",
     "Tournament",
+    "Rd",
     "Rk",
     "vRk",
     "DR",


### PR DESCRIPTION
## Summary
- capture the `Rd` column from the match table and write it to the CSV export
- document the new `Rd` column in the README

## Testing
- `npm test` *(fails: Error: no test specified)*
- `node scrape-tennisabstract.js players_small.txt output_small.csv` *(fails: net::ERR_TUNNEL_CONNECTION_FAILED)*

------
https://chatgpt.com/codex/tasks/task_e_68ac1a9028a08323918b08e066dd96e7